### PR TITLE
Added option for projectId

### DIFF
--- a/iotcore-device.js
+++ b/iotcore-device.js
@@ -251,9 +251,9 @@ module.exports = function(RED) {
                     node.send([msg,]);
                 } else if (topic === `/devices/${node.brokerConn.deviceId}/commands`) {
                     node.send([,msg]);
+                } else {
+                    node.log(RED._(`google-cloud-iotcore: ${message} have been send with the incorrect topic ${topic}`));
                 }
-
-                node.log(RED._(`google-cloud-iotcore: ${message} have been send with the incorrect topic ${topic}`));
             });          
             
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-contrib-iot-in-gcp",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "Node-RED nodes for IoT in Google Cloud Platform",
     "dependencies": {
         "@google-cloud/bigquery": "latest",

--- a/pubsub.html
+++ b/pubsub.html
@@ -7,6 +7,10 @@
         <label for="node-input-keyFilename"><i class="fa fa-file"></i> Key File</label>
         <input type="text" id="node-input-keyFilename">
     </div>
+	<div class="form-row">
+        <label for="node-input-projectId"><i class="fa fa-cloud"></i> Project</label>
+        <input type="text" id="node-input-projectId">
+    </div>
     <div class="form-row">
         <label for="node-input-subscription"><i class="fa fa-bars"></i> Subscription</label>
         <input type="text" id="node-input-subscription">
@@ -44,6 +48,7 @@ RED.nodes.registerType("google-cloud-pubsub receive", {
     defaults: {
         account: { type: "google-cloud-credentials", required: false },
         keyFilename: {value: "", required: false },
+		projectId: { value: "", required: false},
         subscription: { required: true },
         assumeJSON: {value: false, required: false },
         name: { value: "", required: false }

--- a/pubsub.html
+++ b/pubsub.html
@@ -48,7 +48,7 @@ RED.nodes.registerType("google-cloud-pubsub receive", {
     defaults: {
         account: { type: "google-cloud-credentials", required: false },
         keyFilename: {value: "", required: false },
-		projectId: { value: "", required: false},
+        projectId: { value: "", required: false},
         subscription: { required: true },
         assumeJSON: {value: false, required: false },
         name: { value: "", required: false }

--- a/pubsub.js
+++ b/pubsub.js
@@ -105,7 +105,7 @@ module.exports = function(RED) {
             });
         } else {
             pubsub = new PubSub({
-                "projectId": projectId,
+                "projectId": projectId
 			});
         }
 

--- a/pubsub.js
+++ b/pubsub.js
@@ -36,7 +36,7 @@ module.exports = function(RED) {
         if (config.account) {
             credentials = GetCredentials(config.account);
         }
-		let projectId = config.projectId;
+        let projectId = config.projectId;
         if (!projectId || projectId.trim().length == 0) {
             projectId = null;
         }
@@ -95,17 +95,17 @@ module.exports = function(RED) {
         // is an error.  If both are supplied, then credentials will be used.
         if (credentials) {
             pubsub = new PubSub({
-				"projectId": projectId,
+                "projectId": projectId,
                 "credentials": credentials
             });
         } else if (keyFilename) {
             pubsub = new PubSub({
-				"projectId": projectId,
+                "projectId": projectId,
                 "keyFilename": keyFilename
             });
         } else {
             pubsub = new PubSub({
-				"projectId": projectId,
+                "projectId": projectId,
 			});
         }
 

--- a/pubsub.js
+++ b/pubsub.js
@@ -36,6 +36,10 @@ module.exports = function(RED) {
         if (config.account) {
             credentials = GetCredentials(config.account);
         }
+		let projectId = config.projectId;
+        if (!projectId || projectId.trim().length == 0) {
+            projectId = null;
+        }
         const keyFilename = config.keyFilename;
 
         RED.nodes.createNode(this, config);
@@ -91,14 +95,18 @@ module.exports = function(RED) {
         // is an error.  If both are supplied, then credentials will be used.
         if (credentials) {
             pubsub = new PubSub({
+				"projectId": projectId,
                 "credentials": credentials
             });
         } else if (keyFilename) {
             pubsub = new PubSub({
+				"projectId": projectId,
                 "keyFilename": keyFilename
             });
         } else {
-            pubsub = new PubSub({});
+            pubsub = new PubSub({
+				"projectId": projectId,
+			});
         }
 
         node.status(STATUS_CONNECTING);                              // Flag the node as connecting.


### PR DESCRIPTION
Even though the documentation for [ClientConfig](https://cloud.google.com/nodejs/docs/reference/pubsub/0.28.x/global) states the projectId is not necessary when specifying keyFilename it might be needed otherwise, when using credentials parameter for example.